### PR TITLE
Pull Bukkit events rework (internal PR for tracking)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.crashdemons</groupId>
     <artifactId>AztecTabCompleter</artifactId>
-    <version>0.20.0-bukkiteventrework</version>
+    <version>0.20.1-bukkiteventrework</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -66,9 +66,6 @@
     <build>
         <finalName>${project.name}-${project.version}</finalName>
         <resources>
-            <resource>
-                <directory>${basedir}/src/main/java</directory>
-            </resource>
             <resource>
                 <directory>${basedir}/src/main/resources</directory>
                 <filtering>true</filtering>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.crashdemons</groupId>
     <artifactId>AztecTabCompleter</artifactId>
-    <version>0.20.1-bukkiteventrework</version>
+    <version>0.20.2-bukkiteventrework</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.crashdemons</groupId>
     <artifactId>AztecTabCompleter</artifactId>
-    <version>0.19.6-SNAPSHOT</version>
+    <version>0.20.0-bukkiteventrework</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -41,19 +41,10 @@
             <id>md_5-releases</id>
             <url>http://repo.md-5.net/content/repositories/releases/</url>
         </repository>
-        <repository>
-            <id>dmulloy2-repo</id>
-            <url>http://repo.dmulloy2.net/content/groups/public/</url>
-        </repository>
     </repositories>
 
 
     <dependencies>
-        <dependency>
-            <groupId>com.comphenix.protocol</groupId>
-            <artifactId>ProtocolLib</artifactId>
-            <version>4.4.0</version>
-        </dependency>
         <dependency>
             <groupId>com.mojang</groupId>
             <artifactId>brigadier</artifactId>
@@ -66,14 +57,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.13-R0.1-SNAPSHOT</version>
-        </dependency>
-        <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.13-R0.1-SNAPSHOT</version>
+            <version>1.13.2-R0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/github/crashdemons/aztectabcompleter/AZTabPlugin.java
+++ b/src/main/java/com/github/crashdemons/aztectabcompleter/AZTabPlugin.java
@@ -99,7 +99,7 @@ public class AZTabPlugin extends JavaPlugin implements Listener {
         if (player.hasPermission("aztectabcompleter.bypass")) {
             return;
         }
-        if (!ready) {
+        if (!ready || !player.hasPermission("aztectabcompleter.suggest")) {
             event.getCommands().clear();
         } else {
             event.getCommands().removeIf(entry -> !filters.filter(new FilterArgs(player, entry)).isAllowed);

--- a/src/main/java/com/github/crashdemons/aztectabcompleter/AZTabPlugin.java
+++ b/src/main/java/com/github/crashdemons/aztectabcompleter/AZTabPlugin.java
@@ -1,28 +1,7 @@
 package com.github.crashdemons.aztectabcompleter;
 
-
-import com.mojang.brigadier.tree.RootCommandNode;
-import com.mojang.brigadier.tree.CommandNode;
-
-
-import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.ProtocolLibrary;
-import com.comphenix.protocol.ProtocolManager;
-import com.comphenix.protocol.events.ListenerPriority;
-import static com.comphenix.protocol.events.ListenerPriority.HIGH;
-import com.comphenix.protocol.events.PacketAdapter;
-import com.comphenix.protocol.events.PacketContainer;
-import com.comphenix.protocol.events.PacketEvent;
 import com.github.crashdemons.aztectabcompleter.filters.FilterArgs;
 import com.github.crashdemons.aztectabcompleter.filters.FilterSet;
-import com.github.crashdemons.util.Pair;
-import java.lang.reflect.InvocationTargetException;
-import java.net.InetSocketAddress;
-import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.concurrent.ConcurrentHashMap;
-import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -30,11 +9,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandSendEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scheduler.BukkitTask;
 
 /*
  * To change this license header, choose License Headers in Project Properties.
@@ -49,42 +25,17 @@ import org.bukkit.scheduler.BukkitTask;
 public class AZTabPlugin extends JavaPlugin implements Listener {
     //internal variables 
     private static final int TPS = 20;
-    private ProtocolManager protocolManager;
     private FilterSet filters;
     
     //runtime behavior variables
     public volatile boolean loaded = false;
     private volatile boolean ready = false;
     
-    private ConcurrentHashMap<InetSocketAddress,Pair<LocalDateTime,PacketContainer>> packetQueue = new ConcurrentHashMap<>();
-    //don't store Player from packet event since it will be a "temporary" player object that doesn't support every method.
-    
-    private BukkitTask expireQueueEntriesTask=null;
-    private BukkitTask sendQueueEntriesTask=null;
-    
-    private long expirationSeconds=60;
-    private long expirationInterval=60;
-    private long tryUnsentPacketsInterval=10;
+
     
     private boolean kickEarlyJoins=true;
     private String kickMessage="The server is still loading - check back in a moment!";
     
-    private boolean sendPacket(Player playerDestination, PacketContainer packet){
-        if(playerDestination==null) return false;
-        if(!playerDestination.isOnline()) return false;
-        String name = playerDestination.getName();
-        if(name==null) name = "[null]";
-        try{
-            log("Sending commands to "+name);
-            ProtocolLibrary.getProtocolManager().sendServerPacket(playerDestination, packet, false);//send packet - disable further filtering.
-            return true;
-        }catch(IllegalArgumentException e){
-            log("Problem sending packet to " + name +" "+playerDestination.getUniqueId());
-        }catch(InvocationTargetException e){
-            e.printStackTrace();
-        }
-        return false;
-    }
     
     public AZTabPlugin() {
         filters = new FilterSet(this);
@@ -102,12 +53,7 @@ public class AZTabPlugin extends JavaPlugin implements Listener {
         
         kickEarlyJoins = getConfig().getBoolean("kick-early-joins");
         kickMessage = getConfig().getString("kick-message");
-        expirationSeconds = getConfig().getLong("queue-expiration-seconds");
-        expirationInterval = getConfig().getLong("queue-expiration-check-seconds");
-        tryUnsentPacketsInterval=getConfig().getLong("queue-try-unsent-seconds");
-        log("commands queue unsent retry time: "+tryUnsentPacketsInterval+"s");
-        log("commands queue expiration time: "+expirationSeconds+"s");
-        log("commands queue check interval: "+expirationInterval+"s");
+
     }
     
     
@@ -115,8 +61,7 @@ public class AZTabPlugin extends JavaPlugin implements Listener {
     @Override
     public void onDisable() {
         log("Disabling...");
-        if(expireQueueEntriesTask!=null) expireQueueEntriesTask.cancel();
-        if(sendQueueEntriesTask!=null) sendQueueEntriesTask.cancel();
+
         loaded=false;
         log("Disabed.");
     }
@@ -125,36 +70,13 @@ public class AZTabPlugin extends JavaPlugin implements Listener {
     public void onLoad() {
         log("Loading... v"+this.getDescription().getVersion());
         loadConfig();
-        log("Loaded config.");
-        protocolManager = ProtocolLibrary.getProtocolManager();
         loaded=true;
-        
-        createInitialCommandsFilter();
-        log("Created filter.");
+        log("Loaded config.");
     }
     @Override
     public void onEnable() {
         log("Enabling... v"+this.getDescription().getVersion());
         getServer().getPluginManager().registerEvents(this, this);
-        if(expireQueueEntriesTask!=null) expireQueueEntriesTask.cancel();
-        if(sendQueueEntriesTask!=null) sendQueueEntriesTask.cancel();
-        expireQueueEntriesTask = new BukkitRunnable() {
-            public void run() {
-                LocalDateTime now = LocalDateTime.now();
-                packetQueue.entrySet().removeIf((entry)->entry.getValue().getKey().plusSeconds(expirationSeconds).isBefore(LocalDateTime.now())
-                );
-            }
-        }.runTaskTimer(this,expirationInterval*TPS,expirationInterval*TPS);
-        sendQueueEntriesTask = new BukkitRunnable() {
-            public void run() {
-                Bukkit.getOnlinePlayers().stream().forEach(
-                        (player) -> {
-                            if(player==null) return;
-                            processQueueFor(player);
-                        }
-                );
-            }
-        }.runTaskTimer(this,tryUnsentPacketsInterval*TPS,tryUnsentPacketsInterval*TPS);
         loaded=true;
         ready = true;
         log("Enabled.");
@@ -178,8 +100,11 @@ public class AZTabPlugin extends JavaPlugin implements Listener {
     @EventHandler(priority=EventPriority.HIGH)
     public void onCommandSuggestion(PlayerCommandSendEvent event){
         Player player = event.getPlayer();
+        if(player.hasPermission("aztectabcompleter.bypass")) return;
         if(!ready){
             event.getCommands().clear();
+        }else{
+            event.getCommands().removeIf( entry -> !filters.filter(new FilterArgs(player,entry)).isAllowed );
         }
     }
     
@@ -192,94 +117,6 @@ public class AZTabPlugin extends JavaPlugin implements Listener {
                 event.setResult(PlayerLoginEvent.Result.KICK_OTHER);
             }
         }
-    }
-   
-    @EventHandler(priority=EventPriority.HIGH)
-    public void onPlayerJoin(PlayerJoinEvent event){
-        //log("playerjoinevent");
-        if(!loaded) return;
-        if(!ready) return;
-        Player player = event.getPlayer();
-        //log("trying packets for joined player");
-        processQueueFor(player);
-    }
-    
-    private void processQueueFor(Player playerDestination){
-        if(!ready) return;//don't process queued packets until completely enabled!
-        if(playerDestination==null) return;
-        InetSocketAddress addr = playerDestination.getAddress();
-        String name = playerDestination.getName();
-        if(addr==null) return;
-        //log("Player joined: "+uuid);
-        boolean bypassFiltering=playerDestination.hasPermission("aztectabcompleter.bypass");
-        Pair<LocalDateTime,PacketContainer> record = packetQueue.remove(addr);
-        if(record==null) return;
-        PacketContainer packet = record.getValue();
-        if(packet==null) return;
-        PacketContainer packet_filtered;
-        if(bypassFiltering){
-            packet_filtered=packet;
-            //log("player "+name+" is exempt from command filtering");
-        }else{
-            packet_filtered=filterPacketFor(playerDestination,packet);
-            //log("filtered packet for player "+name);
-        }
-        sendPacket(playerDestination,packet_filtered);
-    }
-    private boolean queuePacketFor(Player playerDestination, PacketContainer epacket){
-        InetSocketAddress addr = playerDestination.getAddress();
-        if(addr==null){
-            getLogger().warning("Could not queue packet for player with null address: "+playerDestination.toString());
-            return false;
-        }
-        packetQueue.put(addr, new Pair<LocalDateTime,PacketContainer>(LocalDateTime.now(),epacket));
-        //log("Queued commands for "+uuid);
-        return true;
-    }
-    
-    private PacketContainer filterPacketFor(Player playerDestination, PacketContainer epacket){
-        //the new Commands packet syntax contains a RootNode object containing multiple CommandNode objects inside in the form of a list
-        //CommandNode is difficult to construct, so instead we just selectively remove them from the collection.
-        RootCommandNode rcn = epacket.getSpecificModifier(RootCommandNode.class).read(0);//get the Root object
-        //this.plugin.getLogger().info("RCN Name: "+rcn.getName());
-        //this.plugin.getLogger().info("RCN Usage: "+rcn.getUsageText());
-        @SuppressWarnings("unchecked")
-        Collection<CommandNode<Object>> children = rcn.getChildren();
-        //this.plugin.getLogger().info("RCN Children: "+children.size());
-        Iterator<CommandNode<Object>> iterator = children.iterator();
-        while (iterator.hasNext()) {
-            CommandNode<Object> cn = iterator.next();
-            //this.plugin.getLogger().info("   CN Name: "+cn.getName());
-            //this.plugin.getLogger().info("   CN Usage: "+cn.getUsageText());
-            if(!filters.filter(new FilterArgs(playerDestination,cn.getName())).isAllowed)
-                iterator.remove();
-        }
-        PacketContainer packet = new PacketContainer(PacketType.Play.Server.COMMANDS);
-        packet.getSpecificModifier(RootCommandNode.class).write(0, rcn);//write the modified root object into a new packet
-        return packet;
-    }
-
-    private void createInitialCommandsFilter(){
-        protocolManager.addPacketListener(new PacketAdapter(this, ListenerPriority.HIGHEST, new PacketType[] { PacketType.Play.Server.COMMANDS }) {
-
-        @Override
-        public void onPacketSending (PacketEvent event) {
-            AZTabPlugin pl = (AZTabPlugin) this.plugin;
-           
-            if(!pl.loaded) return;
-            event.setCancelled(true);//prevent default tabcomplete
-            Player playerDestination = event.getPlayer();
-            if(playerDestination==null) return;
-            
-            //pl.log("Intercepted Commands packet, filtering...");
-            
-            PacketContainer epacket = event.getPacket();//get the outgoing spigot packet containing the command list
-            queuePacketFor(playerDestination,epacket);
-            
-            
-        }
-
-    });
     }
     
 }

--- a/src/main/java/com/github/crashdemons/aztectabcompleter/AZTabPlugin.java
+++ b/src/main/java/com/github/crashdemons/aztectabcompleter/AZTabPlugin.java
@@ -17,106 +17,106 @@ import org.bukkit.plugin.java.JavaPlugin;
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
-
 /**
  *
  * @author crash
  */
 public class AZTabPlugin extends JavaPlugin implements Listener {
+
     //internal variables 
-    private static final int TPS = 20;
     private FilterSet filters;
-    
+
     //runtime behavior variables
     public volatile boolean loaded = false;
     private volatile boolean ready = false;
-    
 
-    
-    private boolean kickEarlyJoins=true;
-    private String kickMessage="The server is still loading - check back in a moment!";
-    
-    
+    private boolean kickEarlyJoins = true;
+    private String kickMessage = "The server is still loading - check back in a moment!";
+
     public AZTabPlugin() {
         filters = new FilterSet(this);
     }
-    
-    private void log(String s){
+
+    private void log(String s) {
         getLogger().info(s);
     }
-    
-    private void loadConfig(){
+
+    private void loadConfig() {
         saveDefaultConfig();//fails silently if config exists
         reloadConfig();
-        
+
         filters.load(getConfig());
-        
         kickEarlyJoins = getConfig().getBoolean("kick-early-joins");
         kickMessage = getConfig().getString("kick-message");
-
     }
-    
-    
+
     // Fired when plugin is disabled
     @Override
     public void onDisable() {
         log("Disabling...");
 
-        loaded=false;
+        loaded = false;
         log("Disabed.");
     }
-    
+
     @Override
     public void onLoad() {
-        log("Loading... v"+this.getDescription().getVersion());
+        log("Loading... v" + this.getDescription().getVersion());
         loadConfig();
-        loaded=true;
+        loaded = true;
         log("Loaded config.");
     }
+
     @Override
     public void onEnable() {
-        log("Enabling... v"+this.getDescription().getVersion());
+        log("Enabling... v" + this.getDescription().getVersion());
         getServer().getPluginManager().registerEvents(this, this);
-        loaded=true;
+        loaded = true;
         ready = true;
         log("Enabled.");
     }
-    
-    
-    
-    
+
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
-        if(!loaded) return true;
+        if (!loaded) {
+            return true;
+        }
         if (cmd.getName().equalsIgnoreCase("aztabreload")) {
-            if(!sender.hasPermission("aztectabcompleter.reload")){ sender.sendMessage("You don't have permission to do this."); return true; }
+            if (!sender.hasPermission("aztectabcompleter.reload")) {
+                sender.sendMessage("You don't have permission to do this.");
+                return true;
+            }
             loadConfig();
             sender.sendMessage("[AZTab] Config reloaded.");
             return true;
         }
         return false;
     }
-    
-    @EventHandler(priority=EventPriority.HIGH)
-    public void onCommandSuggestion(PlayerCommandSendEvent event){
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onCommandSuggestion(PlayerCommandSendEvent event) {
         Player player = event.getPlayer();
-        if(player.hasPermission("aztectabcompleter.bypass")) return;
-        if(!ready){
+        if (player.hasPermission("aztectabcompleter.bypass")) {
+            return;
+        }
+        if (!ready) {
             event.getCommands().clear();
-        }else{
-            event.getCommands().removeIf( entry -> !filters.filter(new FilterArgs(player,entry)).isAllowed );
+        } else {
+            event.getCommands().removeIf(entry -> !filters.filter(new FilterArgs(player, entry)).isAllowed);
         }
     }
-    
-    @EventHandler(priority=EventPriority.HIGH)
-    public void onPlayerLogin(PlayerLoginEvent event){
-        if(!loaded) return;
-        if(!ready){
-            if(kickEarlyJoins){
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onPlayerLogin(PlayerLoginEvent event) {
+        if (!loaded) {
+            return;
+        }
+        if (!ready) {
+            if (kickEarlyJoins) {
                 event.setKickMessage(kickMessage);
                 event.setResult(PlayerLoginEvent.Result.KICK_OTHER);
             }
         }
     }
-    
+
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -67,15 +67,6 @@ filter-order: [blacklist,group-blacklists,whitelist,group-whitelists]
 #filter-default: DENY_FINAL
 filter-default: DENY_FINAL
 
-#defines the amount of time that a filtered Commands packet can wait in queue before being sent to a joining user
-queue-expiration-seconds: 60
-
-#defines the interval of time that the plugin will clean up the queue of expired entries
-queue-expiration-check-seconds: 60
-
-#defines the interval of time that the plugin will try to send unsent COMMANDS updates (generally from dimension changes, etc)
-queue-try-unsent-seconds: 10
-
 #kick players who join before the plugin is fully enabled.
 kick-early-joins: true
 kick-message: Please wait a moment for the server to load!

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,25 +9,28 @@ load: STARTUP
 api-version: 1.13
 
 commands:
-   aztabreload:
-      description: reloads aztab config
-      usage: |
-        /aztabreload
-      permission: aztectabcompleter.reload
-      permission-message: You don't have permission for this command
+    aztabreload:
+        description: reloads aztab config
+        usage: |
+          /aztabreload
+        permission: aztectabcompleter.reload
+        permission-message: You don't have permission for this command
       
 permissions:
-  aztectabcompleter.*:
-    description: gives all permissions of the AZTab
-    default: op
-    children:
-        aztectabcompleter.reload: true
-        aztectabcompleter.bypass: true
-aztectabcompleter.reload:
-    description: Gives permission to reload AZTab config
-aztectabcompleter.bypass:
-    description: Gives permission to bypass command filtering by AZTab
-aztectabcompleter.suggest:
-    description: Gives permission to see command suggestions at all (checked before filtering)
-    default: true
+    aztectabcompleter.*:
+        description: gives all permissions of the AZTab
+        default: op
+        children:
+            aztectabcompleter.reload: true
+            aztectabcompleter.bypass: true
+            aztectabcompleter.suggest: true
+    aztectabcompleter.suggest:
+        description: Gives permission to see command suggestions at all (checked before filtering)
+        default: true
+    aztectabcompleter.reload:
+        description: Gives permission to reload AZTab config
+        default: op
+    aztectabcompleter.bypass:
+        description: Gives permission to bypass command filtering by AZTab
+        default: op
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -27,4 +27,7 @@ aztectabcompleter.reload:
     description: Gives permission to reload AZTab config
 aztectabcompleter.bypass:
     description: Gives permission to bypass command filtering by AZTab
+aztectabcompleter.suggest:
+    description: Gives permission to see command suggestions at all (checked before filtering)
+    default: true
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,6 @@ version: ${project.version}
 author: crashdemons
 description: Filters command tab-complete suggestions by whitelist.
 website: https://github.com/crashdemons
-depend: [ProtocolLib]
 load: STARTUP
 
 api-version: 1.13

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,6 +15,11 @@ commands:
           /aztabreload
         permission: aztectabcompleter.reload
         permission-message: You don't have permission for this command
+    aztabdump:
+        description: toggles dumping command filtering information to console
+        usage: /aztabdump
+        permission: aztectabcompleter.dump
+        permission-message: You don't have permission for this command
       
 permissions:
     aztectabcompleter.*:
@@ -33,4 +38,8 @@ permissions:
     aztectabcompleter.bypass:
         description: Gives permission to bypass command filtering by AZTab
         default: op
+    aztectabcompleter.dump:
+        description: Gives permission to enable console logging of filter results
+        default: op
+
 


### PR DESCRIPTION
Pulls changes from the bukkit-events-rework branch.

Removes reliance on ProtocolLib and instead filters commands from PlayerCommandSendEvent.
Bugfix for permissions not correctly enumerated.
Adds Feature #4 
