### PR TITLE
Forward port async fix (from old-name-support)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.crashdemons</groupId>
-    <artifactId>AztecTabFilter</artifactId>
-    <version>0.20.4-SNAPSHOT</version>
+    <artifactId>AztecTabCompleter</artifactId>
+    <version>0.20.5-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -25,17 +25,30 @@
 
     <repositories>
         <repository>
+            <id>papermc</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
+        </repository>
+        <repository>
+            <id>spigot-group-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+        </repository>
+        <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
+            <id>md_5-releases</id>
+            <url>http://repo.md-5.net/content/repositories/releases/</url>
         </repository>
     </repositories>
 
 
     <dependencies>
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.14.3-R0.1-SNAPSHOT</version>
+            <groupId>com.destroystokyo.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.16.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -163,5 +176,5 @@
             </plugins>
         </pluginManagement>
     </build>
-    <name>AztecTabFilter</name>
+    <name>AztecTabCompleter</name>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.crashdemons</groupId>
-    <artifactId>AztecTabCompleter</artifactId>
+    <artifactId>AztecTabFilter</artifactId>
+    <name>AztecTabFilter</name>
     <version>0.20.5-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
@@ -176,5 +177,4 @@
             </plugins>
         </pluginManagement>
     </build>
-    <name>AztecTabCompleter</name>
 </project>

--- a/src/main/java/com/github/crashdemons/aztectabcompleter/AZTabPlugin.java
+++ b/src/main/java/com/github/crashdemons/aztectabcompleter/AZTabPlugin.java
@@ -118,6 +118,9 @@ public class AZTabPlugin extends JavaPlugin implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onCommandSuggestion(PlayerCommandSendEvent event) {
+        if(event.isAsynchronous()){
+            return;
+        }
         Player player = event.getPlayer();
         if (player.hasPermission("aztectabcompleter.bypass")) {
             if(dumpFiltering) getLogger().info(player.getName()+" bypassed filtering by permission.");


### PR DESCRIPTION
a recent Paper change means that duplicate events for PlayerCommandSendEvent are now received, some of which are Async.

This fix is only to avoid errors, it doesn not add support for async command list events - the impacts are not yet well known.

Since this plugin needs to checks users permissions, there may not be a good fix (aside from elaborately scheduling tasks to precache permissions on a sync thread - but what do you do when there is a cache miss?)